### PR TITLE
Limit pillow to v9 or below.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2.0
-pillow
+pillow<10.0.0
 Scipy
 diffusers
 accelerate>=0.30.0


### PR DESCRIPTION
ComfyUI relies on PIL libraries that have LINEAR removed.

`LINEAR` is deprecated and will be removed in Pillow 10 (2023-07-01). Use BILINEAR or Resampling.BILINEAR instead. 

https://github.com/facebookresearch/detectron2/issues/5010

